### PR TITLE
[Draft] Fix local state bug

### DIFF
--- a/test-integration/config/service-route.example.yml
+++ b/test-integration/config/service-route.example.yml
@@ -1,10 +1,21 @@
 services:
-  - name: "mockbin"
-    ensure: "present"
+  - name: mockbin
     attributes:
-      url: "http://mockbin.com"
+      url: http://mockbin.com
+    plugins:
+      - name: rate-limiting
+        attributes:
+          enabled: true
+          config:
+            minute: 60
     routes:
       - name: mockbin
         attributes:
           paths:
             - /mockbin
+        plugins:
+          - name: rate-limiting
+            attributes:
+              enabled: true
+              config:
+                minute: 30


### PR DESCRIPTION
If you run the integration tests against this branch you'll see the following output:

<details>
<summary>Test output</summary>

```
FAIL  test-integration/config.test.js
  ● should apply service-route.example.yml

    expect(received).toEqual(expected) // deep equality

    - Expected
    + Received

    @@ -68,10 +68,34 @@
                  "regex_priority": 0,
                  "strip_path": true,
                },
                "id": "d490b0f0-5ebf-4c5a-817f-ba6fe7842bdb",
                "name": "d490b0f0-5ebf-4c5a-817f-ba6fe7842bdb",
    +           "plugins": Array [],
    +         },
    +         Object {
    +           "_info": Object {
    +             "created_at": 1563910208,
    +             "id": "d490b0f0-5ebf-4c5a-817f-ba6fe7842bdb",
    +             "updated_at": 1563910208,
    +           },
    +           "attributes": Object {
    +             "hosts": null,
    +             "methods": null,
    +             "paths": Array [
    +               "/mockbin",
    +             ],
    +             "preserve_host": false,
    +             "protocols": Array [
    +               "http",
    +               "https",
    +             ],
    +             "regex_priority": 0,
    +             "strip_path": true,
    +           },
    +           "id": "d490b0f0-5ebf-4c5a-817f-ba6fe7842bdb",
    +           "name": "d490b0f0-5ebf-4c5a-817f-ba6fe7842bdb",
                "plugins": Array [
                  Object {
                    "_info": Object {
                      "consumer_id": undefined,
                      "created_at": 1563910208000,

      83 |         expect(getLog()).toMatchSnapshot();
      84 |         expect(exportToYaml(ignoreKeys(kongState))).toMatchSnapshot();
    > 85 |         expect(ignoreConfigOrder(fixRouteNames(getLocalState()))).toEqual(addRouteNullKeys(kongState));
         |                                                                   ^
      86 |     });
      87 | });
      88 |

      at Object.toEqual (test-integration/config.test.js:85:67)


```

</details>

[The line it's failing at](https://github.com/adhocteam/kongfig/blob/master/test-integration/config.test.js#L85) tests whether the kong state as gathered by sending requests to the admin API matches the "local" state. Local state is determined from the log of API responses throughout kongfig's run – it's basically a caching solution. The test failure shows that the local state contains a duplicate copy of the route, which isn't present in the nonlocal state.

I previously encountered an error (that I think is related) where kongfig apply would fail to update the config file with a newly created route id, because the route wasn't present in the final state returned (it was missing [here](https://github.com/adhocteam/kongfig/blob/master/src/cli-apply.js#L82)). I previously thought that was happening when creating that route was the last action taken. I'm no longer sure that's the case! Regardless, something is wrong with the state handling.

It's also worth noting that disabling the "experimental" local state feature is broken.

