### PR TITLE
Stop removing unknown attributes from plugins

### DIFF
--- a/src/readKongApi.js
+++ b/src/readKongApi.js
@@ -65,14 +65,16 @@ export const parsePlugin = (plugin, version) => {
         config,
         id,
         enabled,
-        created_at
+        created_at,
+        ...attributes
     } = plugin
 
     let parsed = {
         name,
         attributes: {
             enabled,
-            config: stripConfig(config)
+            config: stripConfig(config),
+            ...attributes
         },
         _info: {
             id,


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/3086

The `run_on` and `protocols` attributes of plugins were being stripped out from the Kong admin API response, which caused kongfig to always detect a diff if those attributes were present in the yml config.