### PR TITLE
Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adhocteam/kongfig",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "description": "A tool for Kong to allow declarative configuration.",
   "repository": "https://github.com/adhocteam/kongfig",
   "bin": {


### PR DESCRIPTION
We haven't ever updated the version since we've started adding features and fixing bugs. It's not a huge deal because we're not actually publishing this anywhere, but there have been a few times in the past where knowing whether someone had the latest version would have helped debugging.

As we make more and more changes, (and before we move away from running kongfig on our machines), I'd also like to update our kong_sync wrapper script to require a minimum version of kongfig.