### PR TITLE
Use finalPlugin instead of plugin when updating plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adhocteam/kongfig",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adhocteam/kongfig",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A tool for Kong to allow declarative configuration.",
   "repository": "https://github.com/adhocteam/kongfig",
   "bin": {

--- a/src/core.js
+++ b/src/core.js
@@ -729,27 +729,27 @@ function _routePlugin(serviceName, routeName, plugin) {
     const finalPlugin = swapConsumerReference(world, plugin);
     const consumerID = finalPlugin.attributes && getAssociatedEntityID(finalPlugin.attributes, 'consumer');
 
-    if (shouldBeRemoved(plugin)) {
-      if (world.hasRoutePlugin(serviceName, routeName, plugin.name, consumerID)) {
+    if (shouldBeRemoved(finalPlugin)) {
+      if (world.hasRoutePlugin(serviceName, routeName, finalPlugin.name, consumerID)) {
         return removeRoutePlugin(
           world.getServiceId(serviceName),
           world.getServiceRoute(serviceName, routeName).id,
-          world.getRoutePluginId(serviceName, routeName, plugin.name, consumerID)
+          world.getRoutePluginId(serviceName, routeName, finalPlugin.name, consumerID)
         );
       }
 
-      return noop({ type: 'noop-plugin', plugin });
+      return noop({ type: 'noop-plugin', plugin: finalPlugin });
     }
 
-    if (world.hasRoutePlugin(serviceName, routeName, plugin.name, consumerID)) {
-      if (world.isRoutePluginUpToDate(serviceName, routeName, plugin, consumerID)) {
-        return noop({ type: 'noop-plugin', plugin });
+    if (world.hasRoutePlugin(serviceName, routeName, finalPlugin.name, consumerID)) {
+      if (world.isRoutePluginUpToDate(serviceName, routeName, finalPlugin, consumerID)) {
+        return noop({ type: 'noop-plugin', plugin: finalPlugin });
       }
 
       return updateRoutePlugin(
         world.getServiceId(serviceName),
         world.getServiceRoute(serviceName, routeName).id,
-        world.getRoutePluginId(serviceName, routeName, plugin.name, consumerID),
+        world.getRoutePluginId(serviceName, routeName, finalPlugin.name, consumerID),
         finalPlugin.attributes
       );
     }
@@ -757,7 +757,7 @@ function _routePlugin(serviceName, routeName, plugin) {
     return addRoutePlugin(
       world.getServiceId(serviceName),
       world.getServiceRoute(serviceName, routeName).id,
-      plugin.name, finalPlugin.attributes
+      finalPlugin.name, finalPlugin.attributes
     );
   };
 }
@@ -769,23 +769,23 @@ function _servicePlugin(serviceName, plugin) {
     const finalPlugin = swapConsumerReference(world, plugin);
     const consumerID = finalPlugin.attributes && getAssociatedEntityID(finalPlugin.attributes, 'consumer');
 
-    if (shouldBeRemoved(plugin)) {
-      if (world.hasServicePlugin(serviceName, plugin.name, consumerID)) {
-        return removeServicePlugin(world.getServiceId(serviceName), world.getServicePluginId(serviceName, plugin.name, consumerID));
+    if (shouldBeRemoved(finalPlugin)) {
+      if (world.hasServicePlugin(serviceName, finalPlugin.name, consumerID)) {
+        return removeServicePlugin(world.getServiceId(serviceName), world.getServicePluginId(serviceName, finalPlugin.name, consumerID));
       }
 
-      return noop({ type: 'noop-plugin', plugin });
+      return noop({ type: 'noop-plugin', plugin: finalPlugin });
     }
 
-    if (world.hasServicePlugin(serviceName, plugin.name, consumerID)) {
-      if (world.isServicePluginUpToDate(serviceName, plugin, consumerID)) {
-        return noop({ type: 'noop-plugin', plugin });
+    if (world.hasServicePlugin(serviceName, finalPlugin.name, consumerID)) {
+      if (world.isServicePluginUpToDate(serviceName, finalPlugin, consumerID)) {
+        return noop({ type: 'noop-plugin', plugin: finalPlugin });
       }
 
-      return updateServicePlugin(world.getServiceId(serviceName), world.getServicePluginId(serviceName, plugin.name, consumerID), finalPlugin.attributes);
+      return updateServicePlugin(world.getServiceId(serviceName), world.getServicePluginId(serviceName, finalPlugin.name, consumerID), finalPlugin.attributes);
     }
 
-    return addServicePlugin(world.getServiceId(serviceName), plugin.name, finalPlugin.attributes);
+    return addServicePlugin(world.getServiceId(serviceName), finalPlugin.name, finalPlugin.attributes);
   };
 }
 
@@ -796,23 +796,23 @@ function _globalPlugin(plugin) {
     const finalPlugin = swapConsumerReference(world, plugin);
     const consumerID = finalPlugin.attributes && getAssociatedEntityID(finalPlugin.attributes, 'consumer');
 
-    if (shouldBeRemoved(plugin)) {
-      if (world.hasGlobalPlugin(plugin.name, consumerID)) {
-        return removeGlobalPlugin(world.getGlobalPluginId(plugin.name, consumerID));
+    if (shouldBeRemoved(finalPlugin)) {
+      if (world.hasGlobalPlugin(finalPlugin.name, consumerID)) {
+        return removeGlobalPlugin(world.getGlobalPluginId(finalPlugin.name, consumerID));
       }
 
-      return noop({ type: 'noop-global-plugin', plugin });
+      return noop({ type: 'noop-global-plugin', plugin: finalPlugin });
     }
 
-    if (world.hasGlobalPlugin(plugin.name, consumerID)) {
-      if (world.isGlobalPluginUpToDate(plugin, consumerID)) {
-        return noop({ type: 'noop-global-plugin', plugin });
+    if (world.hasGlobalPlugin(finalPlugin.name, consumerID)) {
+      if (world.isGlobalPluginUpToDate(finalPlugin, consumerID)) {
+        return noop({ type: 'noop-global-plugin', plugin: finalPlugin });
       }
 
-      return updateGlobalPlugin(world.getGlobalPluginId(plugin.name, consumerID), finalPlugin.attributes);
+      return updateGlobalPlugin(world.getGlobalPluginId(finalPlugin.name, consumerID), finalPlugin.attributes);
     }
 
-    return addGlobalPlugin(plugin.name, finalPlugin.attributes);
+    return addGlobalPlugin(finalPlugin.name, finalPlugin.attributes);
   }
 }
 

--- a/test-integration/README.md
+++ b/test-integration/README.md
@@ -1,0 +1,3 @@
+## Integration Tests
+
+Integration tests should be ran against Kong 1.x. To get Kong up and running clone [this repo](https://github.com/Kong/docker-kong) and run `docker-compose up` in the compose folder. There should be a Kong server accessible at `localhost:8001` after everything starts up.

--- a/test-integration/__snapshots__/bugs.test.js.snap
+++ b/test-integration/__snapshots__/bugs.test.js.snap
@@ -28,12 +28,26 @@ Array [
     "content": Object {
       "config": Object {
         "credentials": false,
+        "exposed_headers": null,
+        "headers": null,
+        "max_age": null,
+        "methods": null,
+        "origins": null,
         "preflight_continue": false,
       },
+      "consumer": null,
       "created_at": "___created_at___",
       "enabled": true,
       "id": "2b47ba9b-761a-492d-9a0c-000000000001",
       "name": "cors",
+      "protocols": Array [
+        "http",
+        "https",
+      ],
+      "route": null,
+      "run_on": "first",
+      "service": null,
+      "tags": null,
     },
     "ok": true,
     "params": Object {
@@ -82,7 +96,20 @@ plugins:
   - name: cors
     attributes:
       enabled: true
+      service: null
+      protocols:
+        - http
+        - https
+      run_on: first
+      consumer: null
+      route: null
+      tags: null
       config:
+        methods: null
+        exposed_headers: null
+        max_age: null
+        headers: null
+        origins: null
         credentials: false
         preflight_continue: false
 upstreams: []

--- a/test-integration/__snapshots__/config.test.js.snap
+++ b/test-integration/__snapshots__/config.test.js.snap
@@ -118,6 +118,7 @@ rvANyaCjA5QV2cxhZgw9YmwUkP5I6XftplGB81CjmTguGjJ/k5SS8sA2DCHZUna6
 vxTZvHMdrkoTodEYmy67Kno3NZotwhRUIdgdQhDN+aG+wjOCxKMTRQ==
 -----END RSA PRIVATE KEY-----",
       "snis": Array [],
+      "tags": null,
     },
     "ok": true,
     "params": Object {
@@ -206,6 +207,7 @@ vxTZvHMdrkoTodEYmy67Kno3NZotwhRUIdgdQhDN+aG+wjOCxKMTRQ==
       "created_at": "___created_at___",
       "id": "2b47ba9b-761a-492d-9a0c-000000000002",
       "name": "example.com",
+      "tags": null,
     },
     "ok": true,
     "params": Object {
@@ -251,6 +253,7 @@ vxTZvHMdrkoTodEYmy67Kno3NZotwhRUIdgdQhDN+aG+wjOCxKMTRQ==
       "created_at": "___created_at___",
       "id": "2b47ba9b-761a-492d-9a0c-000000000003",
       "name": "www.example.com",
+      "tags": null,
     },
     "ok": true,
     "params": Object {
@@ -395,6 +398,7 @@ Array [
       "created_at": "___created_at___",
       "custom_id": null,
       "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "tags": null,
       "username": "iphone-app",
     },
     "ok": true,
@@ -433,7 +437,9 @@ Array [
   },
   Object {
     "content": Object {
-      "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "consumer": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      },
       "created_at": "___created_at___",
       "id": "2b47ba9b-761a-492d-9a0c-000000000002",
       "key": "very-secret-key",
@@ -477,7 +483,9 @@ Array [
   },
   Object {
     "content": Object {
-      "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "consumer": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      },
       "created_at": "___created_at___",
       "group": "foo-group",
       "id": "2b47ba9b-761a-492d-9a0c-000000000003",
@@ -571,6 +579,8 @@ consumers:
       - name: key-auth
         attributes:
           key: very-secret-key
+          consumer:
+            id: 2b47ba9b-761a-492d-9a0c-000000000001
 plugins: []
 upstreams: []
 certificates: []
@@ -609,13 +619,26 @@ Array [
     "content": Object {
       "config": Object {
         "credentials": false,
+        "exposed_headers": null,
+        "headers": null,
         "max_age": 7000,
+        "methods": null,
+        "origins": null,
         "preflight_continue": false,
       },
+      "consumer": null,
       "created_at": "___created_at___",
       "enabled": true,
       "id": "2b47ba9b-761a-492d-9a0c-000000000001",
       "name": "cors",
+      "protocols": Array [
+        "http",
+        "https",
+      ],
+      "route": null,
+      "run_on": "first",
+      "service": null,
+      "tags": null,
     },
     "ok": true,
     "params": Object {
@@ -672,9 +695,21 @@ plugins:
   - name: cors
     attributes:
       enabled: true
+      service: null
+      protocols:
+        - http
+        - https
+      run_on: first
+      consumer: null
+      route: null
+      tags: null
       config:
-        credentials: false
+        methods: null
+        exposed_headers: null
         max_age: 7000
+        headers: null
+        origins: null
+        credentials: false
         preflight_continue: false
 upstreams: []
 certificates: []
@@ -706,6 +741,7 @@ Array [
       "created_at": "___created_at___",
       "custom_id": null,
       "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "tags": null,
       "username": "iphone-app",
     },
     "ok": true,
@@ -744,7 +780,9 @@ Array [
   },
   Object {
     "content": Object {
-      "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "consumer": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      },
       "created_at": "___created_at___",
       "id": "2b47ba9b-761a-492d-9a0c-000000000002",
       "key": "very-secret-key",
@@ -796,6 +834,7 @@ Array [
       "protocol": "http",
       "read_timeout": 60000,
       "retries": 5,
+      "tags": null,
       "updated_at": "___updated_at___",
       "write_timeout": 60000,
     },
@@ -842,7 +881,7 @@ Array [
   Object {
     "content": Object {
       "config": Object {
-        "anonymous": "",
+        "anonymous": null,
         "hide_credentials": false,
         "key_in_body": false,
         "key_names": Array [
@@ -850,11 +889,21 @@ Array [
         ],
         "run_on_preflight": true,
       },
+      "consumer": null,
       "created_at": "___created_at___",
       "enabled": true,
       "id": "2b47ba9b-761a-492d-9a0c-000000000004",
       "name": "key-auth",
-      "service_id": "2b47ba9b-761a-492d-9a0c-000000000003",
+      "protocols": Array [
+        "http",
+        "https",
+      ],
+      "route": null,
+      "run_on": "first",
+      "service": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000003",
+      },
+      "tags": null,
     },
     "ok": true,
     "params": Object {
@@ -949,6 +998,7 @@ Array [
       "protocol": "http",
       "read_timeout": 60000,
       "retries": 5,
+      "tags": null,
       "updated_at": "___updated_at___",
       "write_timeout": 60000,
     },
@@ -1001,10 +1051,19 @@ exports[`should apply key-auth.example.yml 2`] = `
           config:
             key_names:
               - very-secret-key
-            key_in_body: false
-            anonymous: ''
             run_on_preflight: true
+            anonymous: null
             hide_credentials: false
+            key_in_body: false
+          service:
+            id: 2b47ba9b-761a-492d-9a0c-000000000003
+          protocols:
+            - http
+            - https
+          run_on: first
+          consumer: null
+          route: null
+          tags: null
     routes: []
     attributes:
       host: mockbin.com
@@ -1023,6 +1082,8 @@ consumers:
       - name: key-auth
         attributes:
           key: very-secret-key
+          consumer:
+            id: 2b47ba9b-761a-492d-9a0c-000000000001
 plugins: []
 upstreams: []
 certificates: []
@@ -1054,6 +1115,7 @@ Array [
       "created_at": "___created_at___",
       "custom_id": null,
       "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "tags": null,
       "username": "anonymous-user",
     },
     "ok": true,
@@ -1091,6 +1153,7 @@ Array [
       "created_at": "___created_at___",
       "custom_id": null,
       "id": "2b47ba9b-761a-492d-9a0c-000000000002",
+      "tags": null,
       "username": "iphone-app",
     },
     "ok": true,
@@ -1129,7 +1192,9 @@ Array [
   },
   Object {
     "content": Object {
-      "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000002",
+      "consumer": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000002",
+      },
       "created_at": "___created_at___",
       "id": "2b47ba9b-761a-492d-9a0c-000000000003",
       "key": "very-secret-key",
@@ -1181,6 +1246,7 @@ Array [
       "protocol": "http",
       "read_timeout": 60000,
       "retries": 5,
+      "tags": null,
       "updated_at": "___updated_at___",
       "write_timeout": 60000,
     },
@@ -1236,11 +1302,21 @@ Array [
         ],
         "run_on_preflight": true,
       },
+      "consumer": null,
       "created_at": "___created_at___",
       "enabled": true,
       "id": "2b47ba9b-761a-492d-9a0c-000000000005",
       "name": "key-auth",
-      "service_id": "2b47ba9b-761a-492d-9a0c-000000000004",
+      "protocols": Array [
+        "http",
+        "https",
+      ],
+      "route": null,
+      "run_on": "first",
+      "service": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000004",
+      },
+      "tags": null,
     },
     "ok": true,
     "params": Object {
@@ -1347,6 +1423,7 @@ Array [
       "protocol": "http",
       "read_timeout": 60000,
       "retries": 5,
+      "tags": null,
       "updated_at": "___updated_at___",
       "write_timeout": 60000,
     },
@@ -1371,68 +1448,21 @@ Array [
   },
   Object {
     "params": Object {
-      "body": Object {
-        "config": Object {
-          "anonymous": "2b47ba9b-761a-492d-9a0c-000000000001",
-          "key_names": Array [
-            "very-secret-key",
-          ],
+      "noop": true,
+      "plugin": Object {
+        "attributes": Object {
+          "config": Object {
+            "anonymous": "2b47ba9b-761a-492d-9a0c-000000000001",
+            "key_names": Array [
+              "very-secret-key",
+            ],
+          },
         },
+        "name": "key-auth",
       },
-      "endpoint": Object {
-        "name": "service-plugin",
-        "params": Object {
-          "pluginId": "2b47ba9b-761a-492d-9a0c-000000000005",
-          "serviceId": "2b47ba9b-761a-492d-9a0c-000000000004",
-        },
-      },
-      "method": "PATCH",
-      "type": "update-service-plugin",
+      "type": "noop-plugin",
     },
-    "type": "request",
-    "uri": "http://localhost:8001/plugins/2b47ba9b-761a-492d-9a0c-000000000005",
-  },
-  Object {
-    "content": Object {
-      "config": Object {
-        "anonymous": "2b47ba9b-761a-492d-9a0c-000000000001",
-        "hide_credentials": false,
-        "key_in_body": false,
-        "key_names": Array [
-          "very-secret-key",
-        ],
-        "run_on_preflight": true,
-      },
-      "created_at": "___created_at___",
-      "enabled": true,
-      "id": "2b47ba9b-761a-492d-9a0c-000000000005",
-      "name": "key-auth",
-      "service_id": "2b47ba9b-761a-492d-9a0c-000000000004",
-    },
-    "ok": true,
-    "params": Object {
-      "body": Object {
-        "config": Object {
-          "anonymous": "2b47ba9b-761a-492d-9a0c-000000000001",
-          "key_names": Array [
-            "very-secret-key",
-          ],
-        },
-      },
-      "endpoint": Object {
-        "name": "service-plugin",
-        "params": Object {
-          "pluginId": "2b47ba9b-761a-492d-9a0c-000000000005",
-          "serviceId": "2b47ba9b-761a-492d-9a0c-000000000004",
-        },
-      },
-      "method": "PATCH",
-      "type": "update-service-plugin",
-    },
-    "status": 200,
-    "statusText": "OK",
-    "type": "response",
-    "uri": "http://localhost:8001/plugins/2b47ba9b-761a-492d-9a0c-000000000005",
+    "type": "noop",
   },
 ]
 `;
@@ -1447,10 +1477,19 @@ exports[`should apply key-auth-anonymous.example.yml 2`] = `
           config:
             key_names:
               - very-secret-key
-            key_in_body: false
-            anonymous: 2b47ba9b-761a-492d-9a0c-000000000001
             run_on_preflight: true
+            anonymous: 2b47ba9b-761a-492d-9a0c-000000000001
             hide_credentials: false
+            key_in_body: false
+          service:
+            id: 2b47ba9b-761a-492d-9a0c-000000000004
+          protocols:
+            - http
+            - https
+          run_on: first
+          consumer: null
+          route: null
+          tags: null
     routes: []
     attributes:
       host: mockbin.com
@@ -1473,6 +1512,8 @@ consumers:
       - name: key-auth
         attributes:
           key: very-secret-key
+          consumer:
+            id: 2b47ba9b-761a-492d-9a0c-000000000002
 plugins: []
 upstreams: []
 certificates: []
@@ -1504,6 +1545,7 @@ Array [
       "created_at": "___created_at___",
       "custom_id": null,
       "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "tags": null,
       "username": "user-john",
     },
     "ok": true,
@@ -1549,6 +1591,7 @@ Array [
       "protocol": "http",
       "read_timeout": 60000,
       "retries": 5,
+      "tags": null,
       "updated_at": "___updated_at___",
       "write_timeout": 60000,
     },
@@ -1575,7 +1618,9 @@ Array [
         "config": Object {
           "second": 10,
         },
-        "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+        "consumer": Object {
+          "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+        },
         "name": "rate-limiting",
       },
       "endpoint": Object {
@@ -1594,21 +1639,39 @@ Array [
   Object {
     "content": Object {
       "config": Object {
+        "day": null,
         "fault_tolerant": true,
         "hide_client_headers": false,
+        "hour": null,
         "limit_by": "consumer",
+        "minute": null,
+        "month": null,
         "policy": "cluster",
         "redis_database": 0,
+        "redis_host": null,
+        "redis_password": null,
         "redis_port": 6379,
         "redis_timeout": 2000,
         "second": 10,
+        "year": null,
       },
-      "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "consumer": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      },
       "created_at": "___created_at___",
       "enabled": true,
       "id": "2b47ba9b-761a-492d-9a0c-000000000003",
       "name": "rate-limiting",
-      "service_id": "2b47ba9b-761a-492d-9a0c-000000000002",
+      "protocols": Array [
+        "http",
+        "https",
+      ],
+      "route": null,
+      "run_on": "first",
+      "service": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000002",
+      },
+      "tags": null,
     },
     "ok": true,
     "params": Object {
@@ -1616,7 +1679,9 @@ Array [
         "config": Object {
           "second": 10,
         },
-        "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+        "consumer": Object {
+          "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+        },
         "name": "rate-limiting",
       },
       "endpoint": Object {
@@ -1661,6 +1726,7 @@ Array [
       "protocol": "http",
       "read_timeout": 60000,
       "retries": 5,
+      "tags": null,
       "updated_at": "___updated_at___",
       "write_timeout": 60000,
     },
@@ -1687,7 +1753,9 @@ Array [
         "config": Object {
           "minute": 60,
         },
-        "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+        "consumer": Object {
+          "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+        },
         "enabled": true,
         "name": "rate-limiting",
       },
@@ -1706,20 +1774,37 @@ Array [
   Object {
     "content": Object {
       "config": Object {
+        "day": null,
         "fault_tolerant": true,
         "hide_client_headers": false,
+        "hour": null,
         "limit_by": "consumer",
         "minute": 60,
+        "month": null,
         "policy": "cluster",
         "redis_database": 0,
+        "redis_host": null,
+        "redis_password": null,
         "redis_port": 6379,
         "redis_timeout": 2000,
+        "second": null,
+        "year": null,
       },
-      "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "consumer": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      },
       "created_at": "___created_at___",
       "enabled": true,
       "id": "2b47ba9b-761a-492d-9a0c-000000000005",
       "name": "rate-limiting",
+      "protocols": Array [
+        "http",
+        "https",
+      ],
+      "route": null,
+      "run_on": "first",
+      "service": null,
+      "tags": null,
     },
     "ok": true,
     "params": Object {
@@ -1727,7 +1812,9 @@ Array [
         "config": Object {
           "minute": 60,
         },
-        "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+        "consumer": Object {
+          "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+        },
         "enabled": true,
         "name": "rate-limiting",
       },
@@ -1769,19 +1856,35 @@ Array [
   Object {
     "content": Object {
       "config": Object {
+        "day": null,
         "fault_tolerant": true,
         "hide_client_headers": false,
+        "hour": null,
         "limit_by": "consumer",
         "minute": 30,
+        "month": null,
         "policy": "cluster",
         "redis_database": 0,
+        "redis_host": null,
+        "redis_password": null,
         "redis_port": 6379,
         "redis_timeout": 2000,
+        "second": null,
+        "year": null,
       },
+      "consumer": null,
       "created_at": "___created_at___",
       "enabled": true,
       "id": "2b47ba9b-761a-492d-9a0c-000000000006",
       "name": "rate-limiting",
+      "protocols": Array [
+        "http",
+        "https",
+      ],
+      "route": null,
+      "run_on": "first",
+      "service": null,
+      "tags": null,
     },
     "ok": true,
     "params": Object {
@@ -1849,6 +1952,7 @@ Array [
       "protocol": "http",
       "read_timeout": 60000,
       "retries": 5,
+      "tags": null,
       "updated_at": "___updated_at___",
       "write_timeout": 60000,
     },
@@ -1873,66 +1977,22 @@ Array [
   },
   Object {
     "params": Object {
-      "body": Object {
-        "config": Object {
-          "second": 10,
+      "noop": true,
+      "plugin": Object {
+        "attributes": Object {
+          "config": Object {
+            "second": 10,
+          },
+          "consumer": Object {
+            "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+          },
         },
-        "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+        "ensure": "present",
+        "name": "rate-limiting",
       },
-      "endpoint": Object {
-        "name": "service-plugin",
-        "params": Object {
-          "pluginId": "2b47ba9b-761a-492d-9a0c-000000000003",
-          "serviceId": "2b47ba9b-761a-492d-9a0c-000000000002",
-        },
-      },
-      "method": "PATCH",
-      "type": "update-service-plugin",
+      "type": "noop-plugin",
     },
-    "type": "request",
-    "uri": "http://localhost:8001/plugins/2b47ba9b-761a-492d-9a0c-000000000003",
-  },
-  Object {
-    "content": Object {
-      "config": Object {
-        "fault_tolerant": true,
-        "hide_client_headers": false,
-        "limit_by": "consumer",
-        "policy": "cluster",
-        "redis_database": 0,
-        "redis_port": 6379,
-        "redis_timeout": 2000,
-        "second": 10,
-      },
-      "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
-      "created_at": "___created_at___",
-      "enabled": true,
-      "id": "2b47ba9b-761a-492d-9a0c-000000000003",
-      "name": "rate-limiting",
-      "service_id": "2b47ba9b-761a-492d-9a0c-000000000002",
-    },
-    "ok": true,
-    "params": Object {
-      "body": Object {
-        "config": Object {
-          "second": 10,
-        },
-        "consumer_id": "2b47ba9b-761a-492d-9a0c-000000000001",
-      },
-      "endpoint": Object {
-        "name": "service-plugin",
-        "params": Object {
-          "pluginId": "2b47ba9b-761a-492d-9a0c-000000000003",
-          "serviceId": "2b47ba9b-761a-492d-9a0c-000000000002",
-        },
-      },
-      "method": "PATCH",
-      "type": "update-service-plugin",
-    },
-    "status": 200,
-    "statusText": "OK",
-    "type": "response",
-    "uri": "http://localhost:8001/plugins/2b47ba9b-761a-492d-9a0c-000000000003",
+    "type": "noop",
   },
   Object {
     "params": Object {
@@ -1963,6 +2023,7 @@ Array [
       "protocol": "http",
       "read_timeout": 60000,
       "retries": 5,
+      "tags": null,
       "updated_at": "___updated_at___",
       "write_timeout": 60000,
     },
@@ -1993,8 +2054,10 @@ Array [
           "config": Object {
             "minute": 60,
           },
+          "consumer": Object {
+            "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+          },
           "enabled": true,
-          "username": "user-john",
         },
         "name": "rate-limiting",
       },
@@ -2041,15 +2104,31 @@ exports[`should apply plugin-per-consumer.example.yml 2`] = `
         attributes:
           enabled: true
           config:
-            second: 10
-            redis_database: 0
+            minute: null
             policy: cluster
-            hide_client_headers: false
+            month: null
             redis_timeout: 2000
-            redis_port: 6379
             limit_by: consumer
+            hide_client_headers: false
+            second: 10
+            day: null
+            redis_password: null
+            year: null
+            redis_database: 0
+            hour: null
+            redis_port: 6379
+            redis_host: null
             fault_tolerant: true
-          consumer_id: 2b47ba9b-761a-492d-9a0c-000000000001
+          service:
+            id: 2b47ba9b-761a-492d-9a0c-000000000002
+          protocols:
+            - http
+            - https
+          run_on: first
+          consumer:
+            id: 2b47ba9b-761a-492d-9a0c-000000000001
+          route: null
+          tags: null
     routes: []
     attributes:
       host: mockbin.com
@@ -2069,27 +2148,57 @@ plugins:
   - name: rate-limiting
     attributes:
       enabled: true
+      service: null
+      protocols:
+        - http
+        - https
+      run_on: first
+      consumer: null
+      route: null
+      tags: null
       config:
-        hide_client_headers: false
         minute: 30
         policy: cluster
-        redis_database: 0
+        month: null
         redis_timeout: 2000
-        redis_port: 6379
         limit_by: consumer
+        hide_client_headers: false
+        second: null
+        day: null
+        redis_password: null
+        year: null
+        redis_database: 0
+        hour: null
+        redis_port: 6379
+        redis_host: null
         fault_tolerant: true
   - name: rate-limiting
     attributes:
-      username: user-john
       enabled: true
+      service: null
+      protocols:
+        - http
+        - https
+      run_on: first
+      consumer:
+        id: 2b47ba9b-761a-492d-9a0c-000000000001
+      route: null
+      tags: null
       config:
-        hide_client_headers: false
         minute: 60
         policy: cluster
-        redis_database: 0
+        month: null
         redis_timeout: 2000
-        redis_port: 6379
         limit_by: consumer
+        hide_client_headers: false
+        second: null
+        day: null
+        redis_password: null
+        year: null
+        redis_database: 0
+        hour: null
+        redis_port: 6379
+        redis_host: null
         fault_tolerant: true
 upstreams: []
 certificates: []
@@ -2129,6 +2238,7 @@ Array [
       "protocol": "http",
       "read_timeout": 60000,
       "retries": 5,
+      "tags": null,
       "updated_at": "___updated_at___",
       "write_timeout": 60000,
     },
@@ -2175,9 +2285,11 @@ Array [
   Object {
     "content": Object {
       "created_at": "___created_at___",
+      "destinations": null,
       "hosts": null,
       "id": "2b47ba9b-761a-492d-9a0c-000000000002",
       "methods": null,
+      "name": null,
       "paths": Array [
         "/mockbin",
       ],
@@ -2190,7 +2302,10 @@ Array [
       "service": Object {
         "id": "2b47ba9b-761a-492d-9a0c-000000000001",
       },
+      "snis": null,
+      "sources": null,
       "strip_path": true,
+      "tags": null,
       "updated_at": "___updated_at___",
     },
     "ok": true,
@@ -2251,6 +2366,7 @@ Array [
       "protocol": "http",
       "read_timeout": 60000,
       "retries": 5,
+      "tags": null,
       "updated_at": "___updated_at___",
       "write_timeout": 60000,
     },
@@ -2335,9 +2451,11 @@ Array [
   Object {
     "content": Object {
       "created_at": "___created_at___",
+      "destinations": null,
       "hosts": null,
       "id": "2b47ba9b-761a-492d-9a0c-000000000003",
       "methods": null,
+      "name": null,
       "paths": Array [
         "/mockbin",
       ],
@@ -2350,7 +2468,10 @@ Array [
       "service": Object {
         "id": "2b47ba9b-761a-492d-9a0c-000000000001",
       },
+      "snis": null,
+      "sources": null,
       "strip_path": true,
+      "tags": null,
       "updated_at": "___updated_at___",
     },
     "ok": true,
@@ -2391,13 +2512,20 @@ exports[`should apply service-route.example.yml 2`] = `
         name: 2b47ba9b-761a-492d-9a0c-000000000003
         attributes:
           strip_path: true
+          snis: null
+          hosts: null
+          name: null
+          methods: null
+          sources: null
           preserve_host: false
           regex_priority: 0
           paths:
             - /mockbin
+          destinations: null
           protocols:
             - http
             - https
+          tags: null
     attributes:
       host: mockbin.com
       port: 80
@@ -2439,8 +2567,11 @@ Array [
     "content": Object {
       "created_at": "___created_at___",
       "hash_fallback": "none",
+      "hash_fallback_header": null,
       "hash_on": "none",
+      "hash_on_cookie": null,
       "hash_on_cookie_path": "/",
+      "hash_on_header": null,
       "healthchecks": Object {
         "active": Object {
           "concurrency": 10,
@@ -2453,7 +2584,10 @@ Array [
             "successes": 0,
           },
           "http_path": "/",
+          "https_sni": null,
+          "https_verify_certificate": true,
           "timeout": 1,
+          "type": "http",
           "unhealthy": Object {
             "http_failures": 0,
             "http_statuses": Array [
@@ -2496,6 +2630,7 @@ Array [
             ],
             "successes": 0,
           },
+          "type": "http",
           "unhealthy": Object {
             "http_failures": 0,
             "http_statuses": Array [
@@ -2511,6 +2646,7 @@ Array [
       "id": "2b47ba9b-761a-492d-9a0c-000000000001",
       "name": "mockbinUpstream",
       "slots": 10,
+      "tags": null,
     },
     "ok": true,
     "params": Object {
@@ -2553,7 +2689,9 @@ Array [
       "created_at": "___created_at___",
       "id": "2b47ba9b-761a-492d-9a0c-000000000002",
       "target": "server1.mockbin:3001",
-      "upstream_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "upstream": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      },
       "weight": 50,
     },
     "ok": true,
@@ -2601,7 +2739,9 @@ Array [
       "created_at": "___created_at___",
       "id": "2b47ba9b-761a-492d-9a0c-000000000003",
       "target": "server2.mockbin:3001",
-      "upstream_id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "upstream": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      },
       "weight": 50,
     },
     "ok": true,

--- a/test-integration/__snapshots__/plugin.test.js.snap
+++ b/test-integration/__snapshots__/plugin.test.js.snap
@@ -1,0 +1,188 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`global plugins should properly swap username for consumer id 1`] = `
+Array [
+  Object {
+    "type": "kong-info",
+    "version": "___version___",
+  },
+  Object {
+    "params": Object {
+      "body": Object {
+        "username": "user",
+      },
+      "endpoint": Object {
+        "name": "consumers",
+      },
+      "method": "POST",
+      "type": "create-customer",
+    },
+    "type": "request",
+    "uri": "http://localhost:8001/consumers",
+  },
+  Object {
+    "content": Object {
+      "created_at": "___created_at___",
+      "custom_id": null,
+      "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      "tags": null,
+      "username": "user",
+    },
+    "ok": true,
+    "params": Object {
+      "body": Object {
+        "username": "user",
+      },
+      "endpoint": Object {
+        "name": "consumers",
+      },
+      "method": "POST",
+      "type": "create-customer",
+    },
+    "status": 201,
+    "statusText": "Created",
+    "type": "response",
+    "uri": "http://localhost:8001/consumers",
+  },
+  Object {
+    "params": Object {
+      "body": Object {
+        "config": Object {
+          "fault_tolerant": true,
+          "hide_client_headers": false,
+          "limit_by": "consumer",
+          "policy": "cluster",
+          "redis_database": 0,
+          "redis_port": 6379,
+          "redis_timeout": 2000,
+          "second": 5,
+        },
+        "consumer": Object {
+          "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+        },
+        "enabled": true,
+        "name": "rate-limiting",
+      },
+      "endpoint": Object {
+        "name": "plugins",
+        "params": Object {
+          "pluginName": "rate-limiting",
+        },
+      },
+      "method": "POST",
+      "type": "add-global-plugin",
+    },
+    "type": "request",
+    "uri": "http://localhost:8001/plugins",
+  },
+  Object {
+    "content": Object {
+      "config": Object {
+        "day": null,
+        "fault_tolerant": true,
+        "hide_client_headers": false,
+        "hour": null,
+        "limit_by": "consumer",
+        "minute": null,
+        "month": null,
+        "policy": "cluster",
+        "redis_database": 0,
+        "redis_host": null,
+        "redis_password": null,
+        "redis_port": 6379,
+        "redis_timeout": 2000,
+        "second": 5,
+        "year": null,
+      },
+      "consumer": Object {
+        "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+      },
+      "created_at": "___created_at___",
+      "enabled": true,
+      "id": "2b47ba9b-761a-492d-9a0c-000000000002",
+      "name": "rate-limiting",
+      "protocols": Array [
+        "http",
+        "https",
+      ],
+      "route": null,
+      "run_on": "first",
+      "service": null,
+      "tags": null,
+    },
+    "ok": true,
+    "params": Object {
+      "body": Object {
+        "config": Object {
+          "fault_tolerant": true,
+          "hide_client_headers": false,
+          "limit_by": "consumer",
+          "policy": "cluster",
+          "redis_database": 0,
+          "redis_port": 6379,
+          "redis_timeout": 2000,
+          "second": 5,
+        },
+        "consumer": Object {
+          "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+        },
+        "enabled": true,
+        "name": "rate-limiting",
+      },
+      "endpoint": Object {
+        "name": "plugins",
+        "params": Object {
+          "pluginName": "rate-limiting",
+        },
+      },
+      "method": "POST",
+      "type": "add-global-plugin",
+    },
+    "status": 201,
+    "statusText": "Created",
+    "type": "response",
+    "uri": "http://localhost:8001/plugins",
+  },
+  Object {
+    "type": "kong-info",
+    "version": "___version___",
+  },
+  Object {
+    "params": Object {
+      "consumer": Object {
+        "ensure": "present",
+        "username": "user",
+      },
+      "noop": true,
+      "type": "noop-consumer",
+    },
+    "type": "noop",
+  },
+  Object {
+    "params": Object {
+      "noop": true,
+      "plugin": Object {
+        "attributes": Object {
+          "config": Object {
+            "fault_tolerant": true,
+            "hide_client_headers": false,
+            "limit_by": "consumer",
+            "policy": "cluster",
+            "redis_database": 0,
+            "redis_port": 6379,
+            "redis_timeout": 2000,
+            "second": 5,
+          },
+          "consumer": Object {
+            "id": "2b47ba9b-761a-492d-9a0c-000000000001",
+          },
+          "enabled": true,
+        },
+        "name": "rate-limiting",
+      },
+      "type": "noop-global-plugin",
+    },
+    "type": "noop",
+  },
+]
+`;

--- a/test-integration/plugin.test.js
+++ b/test-integration/plugin.test.js
@@ -1,0 +1,43 @@
+import execute from '../src/core';
+import { testAdminApi, logger, getLog, tearDown } from '../test-integration/util';
+import 'core-js/features/object/from-entries';
+
+beforeEach(tearDown);
+jest.setTimeout(10000);
+
+describe('global plugins', () => {
+  it('should properly swap username for consumer id', async () => {
+    const config = {
+      plugins: [
+        {
+          name: 'rate-limiting',
+          attributes: {
+            enabled: true,
+            username: 'user',
+            config: {
+              second: 5,
+              redis_database: 0,
+              policy: 'cluster',
+              hide_client_headers: false,
+              redis_timeout: 2000,
+              redis_port: 6379,
+              limit_by: 'consumer',
+              fault_tolerant: true
+            }
+          }
+        }
+      ],
+      consumers: [
+        {
+          username: 'user',
+          ensure: 'present'
+        }
+      ]
+    }
+
+    await execute(config, testAdminApi, logger);
+    await execute(config, testAdminApi, logger);
+
+    expect(getLog()).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/3175

`finalPlugin` is a copy of `plugin` but switches out `consumer_username` for `consumer_id`. This updates kongfig to use `finalPlugin` instead of `plugin`. Instead of comparing a `consumer_username` (from local config) to a `consumer_id` (from the kong server), which always reports a diff and causes a no-op update to hit the server, kongfig now compares `consumer_id` to `consumer_id`. See the definition for [swapConsumerReference](https://github.com/adhocteam/kongfig/blob/master/src/core.js#L672)