### PR TITLE
Fix integration test config loading

### DIFF
--- a/test-integration/config.test.js
+++ b/test-integration/config.test.js
@@ -74,7 +74,7 @@ const addRouteNullKeys = state => { debugger; return ({
 fs.readdirSync(path.resolve(__dirname, './config')).forEach(filename => {
     it(`should apply ${filename}`, async () => {
         const configPath = path.resolve(__dirname, './config', filename);
-        const config = configLoader(configPath);
+        const [config, _] = configLoader(configPath);
 
         await execute(config, testAdminApi, logger);
         await execute(config, testAdminApi, logger); // all the actions should be no-op


### PR DESCRIPTION
The return type of `configLoader` changed to an array in
https://github.com/adhocteam/kongfig/pull/25 but the integration tests
weren't updated.