### PR TITLE
Freeze package.version in kongfig executable with Babel plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
     }]
   ],
   "plugins": [
-    "@babel/plugin-proposal-object-rest-spread"
+    "@babel/plugin-proposal-object-rest-spread",
+    "version"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1722,6 +1722,12 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-plugin-version": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-version/-/babel-plugin-version-0.2.3.tgz",
+      "integrity": "sha512-YylmpgfdYrCiLGLtR7tLa+VYXJAadBSeH7asYvVLQPlooyQYQ1YFemiGZcryWsIyoj8w6P20qW0y7y6+AiDFbQ==",
+      "dev": true
+    },
     "babel-preset-env": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adhocteam/kongfig",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A tool for Kong to allow declarative configuration.",
   "repository": "https://github.com/adhocteam/kongfig",
   "bin": {
@@ -46,6 +46,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.3.1",
     "babel-jest": "^24.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-version": "^0.2.3",
     "babel-preset-env": "^1.7.0",
     "core-js": "^3.1.4",
     "expect.js": "^0.3.1",

--- a/src/cli-apply.js
+++ b/src/cli-apply.js
@@ -11,7 +11,6 @@ import {addSchemasFromOptions, addSchemasFromConfig} from './consumerCredentials
 import isEqual from 'lodash.isequal';
 
 program
-    .version(require("../package.json").version)
     .option('--path <value>', 'Path to the configuration file')
     .option('--host <value>', 'Kong admin host (default: localhost:8001)')
     .option('--output <value>', 'File with updated route ids overwrites path by default')

--- a/src/cli-dump.js
+++ b/src/cli-dump.js
@@ -9,7 +9,6 @@ import {addSchemasFromOptions} from './consumerCredentials';
 import program from 'commander';
 
 program
-    .version(require("../package.json").version)
     .option('-f, --format <value>', 'Export format [screen, json, yaml] (default: yaml)', /^(screen|json|yaml|yml)$/, 'yaml')
     .option('--host <value>', 'Kong admin host (default: localhost:8001)', 'localhost:8001')
     .option('--https', 'Use https for admin API requests')

--- a/src/cli-prune.js
+++ b/src/cli-prune.js
@@ -12,7 +12,6 @@ import { pretty } from './prettyConfig';
 import { shouldBeRemoved } from './utils'
 
 program
-  .version(require("../package.json").version)
   .option('--path <value>', 'Path to the configuration file')
   .option('--output <value>', 'File with updated route ids overwrites path by default')
   .parse(process.argv);

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 import commander from 'commander';
 
 commander
-    .version(__VERSION__)
+    .version(__VERSION__, '-v, --version, --compiled-version')
     .allowUnknownOption()
     .command('apply', 'Apply config to a kong server', {isDefault: true})
     .command('dump', 'Dump the configuration from a kong server')

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,9 +1,7 @@
 import commander from 'commander';
 
-let pkg = require("../package.json");
-
 commander
-    .version(pkg.version)
+    .version(__VERSION__)
     .allowUnknownOption()
     .command('apply', 'Apply config to a kong server', {isDefault: true})
     .command('dump', 'Dump the configuration from a kong server')

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 import commander from 'commander';
 
 commander
-    .version(__VERSION__, '-v, --version, --compiled-version')
+    .version(__VERSION__, '-v, --version')
     .allowUnknownOption()
     .command('apply', 'Apply config to a kong server', {isDefault: true})
     .command('dump', 'Dump the configuration from a kong server')


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/3563

instead of requiring `package.json` in the `cli` module and using `package.version` for the kongfig version, this uses a special variable `__VERSION__` which [`babel-plugin-version`](https://www.npmjs.com/package/babel-plugin-version) compiles to the value of `package.version` at build time.

therefore, the following should all return the same version:

```
~$ kongfig --version
~/kongfig$ bin/kongfig --version
```

my compiled `lib/cli.js` (with spacing):

```
"use strict";

var _commander = require("commander");

var _commander2 = _interopRequireDefault(_commander);

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

_commander2.default.version("3.0.1")
  .allowUnknownOption()
  .command('apply', 'Apply config to a kong server', {
    isDefault: true
  })
  .command('dump', 'Dump the configuration from a kong server')
  .command('prune', 'Rewrites config omitting any service, route, global plugin or service/route plugin marked "ensure: removed"')
  .parse(process.argv);
```

once this is merged to master, we'll need to require `3.0.1` or greater in `kong_sync`. at that point, we can implement the change that @kalilsn started at one point (i think?) to automatically require the version from the github repo. at that point, the github version will be at least `3.0.1`, so they will have to have a version (from either the manual or dynamic requirement) that, when built, correctly reports its version. then that dynamic check in `kong_sync` should work. let's discuss this to make sure we're on the same page.